### PR TITLE
Clean up client trait definition and more descriptive errors.

### DIFF
--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -463,7 +463,8 @@ impl ClientDef for TendermintClient {
         _proof_upgrade_client: Vec<u8>,
         _proof_upgrade_consensus_state: Vec<u8>,
     ) -> Result<(Self::ClientState, ConsensusUpdateResult), Ics02Error> {
-        todo!()
+        // TODO:
+        Err(Ics02Error::implementation_specific("Not implemented".to_string()))
     }
 }
 

--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -464,7 +464,9 @@ impl ClientDef for TendermintClient {
         _proof_upgrade_consensus_state: Vec<u8>,
     ) -> Result<(Self::ClientState, ConsensusUpdateResult), Ics02Error> {
         // TODO:
-        Err(Ics02Error::implementation_specific("Not implemented".to_string()))
+        Err(Ics02Error::implementation_specific(
+            "Not implemented".to_string(),
+        ))
     }
 }
 

--- a/modules/src/clients/ics11_beefy/client_def.rs
+++ b/modules/src/clients/ics11_beefy/client_def.rs
@@ -198,7 +198,9 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for BeefyClient<HostFunctio
         _proof_upgrade_consensus_state: Vec<u8>,
     ) -> Result<(Self::ClientState, ConsensusUpdateResult), Error> {
         // TODO:
-        Err(Error::beefy(BeefyError::implementation_specific("Not implemented".to_string())))
+        Err(Error::beefy(BeefyError::implementation_specific(
+            "Not implemented".to_string(),
+        )))
     }
 
     fn verify_client_consensus_state(

--- a/modules/src/clients/ics11_beefy/client_def.rs
+++ b/modules/src/clients/ics11_beefy/client_def.rs
@@ -197,7 +197,8 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for BeefyClient<HostFunctio
         _proof_upgrade_client: Vec<u8>,
         _proof_upgrade_consensus_state: Vec<u8>,
     ) -> Result<(Self::ClientState, ConsensusUpdateResult), Error> {
-        todo!()
+        // TODO:
+        Err(Error::beefy(BeefyError::implementation_specific("Not implemented".to_string())))
     }
 
     fn verify_client_consensus_state(

--- a/modules/src/clients/ics11_beefy/error.rs
+++ b/modules/src/clients/ics11_beefy/error.rs
@@ -16,22 +16,29 @@ define_error! {
     Error {
         InvalidAddress
             |_| { "invalid address" },
+
         InvalidTrieProof
             |_| { "invalid trie proof" },
+
         InvalidMmrUpdate
             { reason: String }
             |e| { format_args!("invalid mmr update {}", e.reason) },
+
         InvalidCommitmentRoot
             |_| { "invalid commitment root" },
+
         TimestampExtrinsic
             { reason: String }
             |e| { format_args!("error decoding timestamp extrinsic {}", e.reason) },
+
         InvalidHeader
             { reason: String }
             |e| { format_args!("invalid header, failed basic validation: {}", e.reason) },
+
         ImplementationSpecific
             { reason: String }
             |e| { format_args!("Implementation specific error: {}", e.reason) },
+
         Validation
             { reason: String }
             |e| { format_args!("invalid header, failed basic validation: {}", e.reason) },
@@ -135,15 +142,6 @@ define_error! {
                 format_args!("header height = {0} is invalid", e.height)
             },
 
-        InvalidTrustedHeaderHeight
-            {
-                trusted_header_height: Height,
-                height_header: Height
-            }
-            | e | {
-                format_args!("header height is {0} and is lower than the trusted header height, which is {1} ", e.height_header, e.trusted_header_height)
-            },
-
         LowUpdateHeight
             {
                 low: Height,
@@ -151,21 +149,6 @@ define_error! {
             }
             | e | {
                 format_args!("header height is {0} but it must be greater than the current client height which is {1}", e.low, e.high)
-            },
-
-        MismatchedRevisions
-            {
-                current_revision: u64,
-                update_revision: u64,
-            }
-            | e | {
-                format_args!("the header's current/trusted revision number ({0}) and the update's revision number ({1}) should be the same", e.current_revision, e.update_revision)
-            },
-
-        VerificationError
-            { reason: BeefyClientError }
-            | e | {
-                format_args!("verification failed: {:?}", e.reason)
             },
 
         ProcessedTimeNotFound
@@ -188,6 +171,13 @@ define_error! {
                 format_args!(
                     "Processed height for the client {0} at height {1} not found",
                     e.client_id, e.height)
+            },
+
+
+        VerificationError
+            { reason: BeefyClientError }
+            | e | {
+                format_args!("verification failed: {:?}", e.reason)
             },
 
         Ics23Error

--- a/modules/src/core/ics02_client/context.rs
+++ b/modules/src/core/ics02_client/context.rs
@@ -61,18 +61,10 @@ pub trait ClientReader {
     fn host_height(&self) -> Height;
 
     /// Returns the current timestamp of the local chain.
-    fn host_timestamp(&self) -> Timestamp {
-        let pending_consensus_state = self
-            .pending_host_consensus_state()
-            .expect("host must have pending consensus state");
-        pending_consensus_state.timestamp()
-    }
+    fn host_timestamp(&self) -> Timestamp;
 
     /// Returns the `ConsensusState` of the host (local) chain at a specific height.
     fn host_consensus_state(&self, height: Height) -> Result<AnyConsensusState, Error>;
-
-    /// Returns the pending `ConsensusState` of the host (local) chain.
-    fn pending_host_consensus_state(&self) -> Result<AnyConsensusState, Error>;
 
     /// Returns a natural number, counting how many clients have been created thus far.
     /// The value of this counter should increase only via method `ClientKeeper::increase_client_counter`.

--- a/modules/src/core/ics02_client/error.rs
+++ b/modules/src/core/ics02_client/error.rs
@@ -51,7 +51,8 @@ define_error! {
             },
 
         ImplementationSpecific
-            | _ | { "implementation specific error" },
+            { reason: String }
+            | e | { format_args!("implementation specific error: {}", e.reason) },
 
         HeaderVerificationFailure
             { reason: String }

--- a/modules/src/core/ics03_connection/error.rs
+++ b/modules/src/core/ics03_connection/error.rs
@@ -2,10 +2,10 @@ use crate::core::ics02_client::error as client_error;
 use crate::core::ics03_connection::version::Version;
 use crate::core::ics24_host::error::ValidationError;
 use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
+use crate::prelude::*;
 use crate::proofs::ProofError;
 use crate::Height;
 use flex_error::define_error;
-use crate::prelude::*;
 
 define_error! {
     #[derive(Debug, PartialEq, Eq)]

--- a/modules/src/core/ics03_connection/error.rs
+++ b/modules/src/core/ics03_connection/error.rs
@@ -5,6 +5,7 @@ use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
 use crate::proofs::ProofError;
 use crate::Height;
 use flex_error::define_error;
+use crate::prelude::*;
 
 define_error! {
     #[derive(Debug, PartialEq, Eq)]
@@ -153,6 +154,7 @@ define_error! {
             },
 
         ImplementationSpecific
-            | _ | { "implementation specific error" },
+            { reason: String }
+            | e | { format_args!("implementation specific error: {}", e.reason) },
     }
 }

--- a/modules/src/core/ics04_channel/error.rs
+++ b/modules/src/core/ics04_channel/error.rs
@@ -340,7 +340,8 @@ define_error! {
             | _ | { "route not found" },
 
         ImplementationSpecific
-            | _ | { "implementation specific error" },
+            { reason: String }
+            | e | { format_args!("implementation specific error: {}", e.reason) },
     }
 }
 

--- a/modules/src/core/ics04_channel/handler/recv_packet.rs
+++ b/modules/src/core/ics04_channel/handler/recv_packet.rs
@@ -13,6 +13,7 @@ use crate::handler::{HandlerOutput, HandlerResult};
 use crate::timestamp::Expiry;
 use crate::Height;
 use core::fmt::Debug;
+use crate::prelude::*;
 
 #[derive(Clone, Debug)]
 pub struct RecvPacketSuccess {
@@ -136,7 +137,7 @@ pub fn process<HostFunctions: HostFunctionsProvider>(
                     receipt: Some(Receipt::Ok),
                 }))
             }
-            Err(_) => return Err(Error::implementation_specific()),
+            Err(e) => return Err(Error::implementation_specific(e.to_string())),
         }
     };
 

--- a/modules/src/core/ics04_channel/handler/recv_packet.rs
+++ b/modules/src/core/ics04_channel/handler/recv_packet.rs
@@ -10,10 +10,10 @@ use crate::core::ics24_host::identifier::{ChannelId, PortId};
 use crate::core::ics26_routing::context::LightClientContext;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
+use crate::prelude::*;
 use crate::timestamp::Expiry;
 use crate::Height;
 use core::fmt::Debug;
-use crate::prelude::*;
 
 #[derive(Clone, Debug)]
 pub struct RecvPacketSuccess {

--- a/modules/src/core/ics04_channel/handler/send_packet.rs
+++ b/modules/src/core/ics04_channel/handler/send_packet.rs
@@ -54,7 +54,7 @@ pub fn send_packet(
 
     let client_state = ctx
         .client_state(&client_id)
-        .map_err(|_| Error::implementation_specific())?;
+        .map_err(|e| Error::implementation_specific(e.to_string()))?;
 
     // prevent accidental sends with clients that cannot be updated
     if client_state.is_frozen() {

--- a/modules/src/core/ics05_port/error.rs
+++ b/modules/src/core/ics05_port/error.rs
@@ -1,6 +1,6 @@
 use crate::core::ics24_host::identifier::PortId;
-use flex_error::define_error;
 use crate::prelude::*;
+use flex_error::define_error;
 
 define_error! {
     #[derive(Debug, PartialEq, Eq, derive_more::From)]

--- a/modules/src/core/ics05_port/error.rs
+++ b/modules/src/core/ics05_port/error.rs
@@ -1,5 +1,6 @@
 use crate::core::ics24_host::identifier::PortId;
 use flex_error::define_error;
+use crate::prelude::*;
 
 define_error! {
     #[derive(Debug, PartialEq, Eq, derive_more::From)]
@@ -17,6 +18,7 @@ define_error! {
             | e | { format_args!("could not retrieve module from port '{0}'", e.port_id) },
 
         ImplementationSpecific
-            | _ | { "implementation specific error" },
+            { reason: String }
+            | e | { format_args!("implementation specific error: {}", e.reason) },
     }
 }

--- a/modules/src/mock/context.rs
+++ b/modules/src/mock/context.rs
@@ -1016,10 +1016,6 @@ impl ClientReader for MockContext {
         }
     }
 
-    fn pending_host_consensus_state(&self) -> Result<AnyConsensusState, Ics02Error> {
-        Err(Ics02Error::missing_local_consensus_state(Height::zero()))
-    }
-
     fn client_counter(&self) -> Result<u64, Ics02Error> {
         Ok(self.client_ids_counter)
     }


### PR DESCRIPTION
This PR removes the `pending_host_consensus_state` method, since it's not a necessary method, the host timestamp can be implemented without this method.
Mandates `implementation_specific` error types to come with a description that could explain the source of the error.