### PR TITLE
Expose inner value in `Amount` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,11 +1615,13 @@ dependencies = [
  "parity-scale-codec",
  "prost",
  "prost-types",
+ "ripemd",
  "safe-regex",
  "serde",
  "serde_derive",
  "serde_json",
  "sha2 0.10.2",
+ "sha3",
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.22)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.22)",
  "sp-mmr-primitives",
@@ -1628,9 +1630,9 @@ dependencies = [
  "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.22)",
  "subtle-encoding",
  "subxt",
- "tendermint 0.23.7 (git+https://github.com/composableFi/tendermint-rs?branch=seun-0.23.7)",
+ "tendermint",
  "tendermint-light-client-verifier",
- "tendermint-proto 0.23.7 (git+https://github.com/composableFi/tendermint-rs?branch=seun-0.23.7)",
+ "tendermint-proto",
  "tendermint-rpc",
  "tendermint-testgen",
  "test-log",
@@ -1651,7 +1653,7 @@ dependencies = [
  "prost-types",
  "schemars",
  "serde",
- "tendermint-proto 0.23.7 (git+https://github.com/composableFi/tendermint-rs?branch=seun-0.23.7)",
+ "tendermint-proto",
  "tonic",
 ]
 
@@ -3040,6 +3042,15 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1facec54cb5e0dc08553501fa740091086d0259ad0067e0d4103448e4cb22ed3"
+dependencies = [
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -4547,35 +4558,6 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca881fa4dedd2b46334f13be7fbc8cc1549ba4be5a833fe4e73d1a1baaf7949"
-dependencies = [
- "async-trait",
- "bytes",
- "ed25519",
- "ed25519-dalek",
- "flex-error",
- "futures",
- "num-traits",
- "once_cell",
- "prost",
- "prost-types",
- "serde",
- "serde_bytes",
- "serde_json",
- "serde_repr",
- "sha2 0.9.9",
- "signature",
- "subtle",
- "subtle-encoding",
- "tendermint-proto 0.23.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "time",
- "zeroize",
-]
-
-[[package]]
-name = "tendermint"
-version = "0.23.7"
 source = "git+https://github.com/composableFi/tendermint-rs?branch=seun-0.23.7#cb79c164e84c3d9176b374f2b227393fe000e691"
 dependencies = [
  "async-trait",
@@ -4596,7 +4578,7 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto 0.23.7 (git+https://github.com/composableFi/tendermint-rs?branch=seun-0.23.7)",
+ "tendermint-proto",
  "time",
  "zeroize",
 ]
@@ -4604,13 +4586,12 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c56ee93f4e9b7e7daba86d171f44572e91b741084384d0ae00df7991873dfd"
+source = "git+https://github.com/composableFi/tendermint-rs?branch=seun-0.23.7#cb79c164e84c3d9176b374f2b227393fe000e691"
 dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint 0.23.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tendermint",
  "toml",
  "url",
 ]
@@ -4623,25 +4604,7 @@ dependencies = [
  "derive_more",
  "flex-error",
  "serde",
- "tendermint 0.23.7 (git+https://github.com/composableFi/tendermint-rs?branch=seun-0.23.7)",
- "time",
-]
-
-[[package]]
-name = "tendermint-proto"
-version = "0.23.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71f925d74903f4abbdc4af0110635a307b3cb05b175fdff4a7247c14a4d0874"
-dependencies = [
- "bytes",
- "flex-error",
- "num-derive",
- "num-traits",
- "prost",
- "prost-types",
- "serde",
- "serde_bytes",
- "subtle-encoding",
+ "tendermint",
  "time",
 ]
 
@@ -4665,8 +4628,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e63f57ee05a1e927887191c76d1b139de9fa40c180b9f8727ee44377242a6"
+source = "git+https://github.com/composableFi/tendermint-rs?branch=seun-0.23.7#cb79c164e84c3d9176b374f2b227393fe000e691"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -4684,9 +4646,9 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "subtle-encoding",
- "tendermint 0.23.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tendermint",
  "tendermint-config",
- "tendermint-proto 0.23.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tendermint-proto",
  "thiserror",
  "time",
  "tokio",
@@ -4699,8 +4661,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442ede2d01e61466e515fd7f1d0aac7c3c86b3066535479caa86a43afb5e2e17"
+source = "git+https://github.com/composableFi/tendermint-rs?branch=seun-0.23.7#cb79c164e84c3d9176b374f2b227393fe000e691"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",
@@ -4708,7 +4669,7 @@ dependencies = [
  "serde_json",
  "simple-error",
  "tempfile",
- "tendermint 0.23.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tendermint",
  "time",
 ]
 

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -83,7 +83,8 @@ branch = "seun-0.23.7"
 default-features = false
 
 [dependencies.tendermint-testgen]
-version = "=0.23.7"
+git = "https://github.com/composableFi/tendermint-rs"
+branch = "seun-0.23.7"
 optional = true
 default-features = false
 
@@ -93,14 +94,16 @@ tracing-subscriber = { version = "0.3.11", features = ["fmt", "env-filter", "jso
 test-log = { version = "0.2.10", features = ["trace"] }
 modelator = "0.4.2"
 sha2 = { version = "0.10.2" }
-tendermint-rpc = { version = "=0.23.7", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "=0.23.7" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { git = "https://github.com/composableFi/tendermint-rs", branch = "seun-0.23.7", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { git = "https://github.com/composableFi/tendermint-rs", branch = "seun-0.23.7" } # Needed for generating (synthetic) light blocks.
 # Beefy Light Client testing dependencies
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22"}
 subxt = "0.21.0"
 tokio = { version = "1.17.0", features = ["full"] }
 serde_json = "1.0.74"
 beefy-client = { package = "beefy-generic-client",  git = "https://github.com/ComposableFi/beefy-client", branch = "master", features = ["mocks"]}
+sha3 = { version = "0.10.1" }
+ripemd = { version = "0.1.1" }
 
 [[test]]
 name = "mbt"

--- a/modules/src/applications/transfer/denom.rs
+++ b/modules/src/applications/transfer/denom.rs
@@ -289,6 +289,10 @@ impl Amount {
     pub fn checked_sub(self, rhs: Self) -> Option<Self> {
         self.0.checked_sub(rhs.0).map(Self)
     }
+
+    pub fn as_u256(&self) -> U256 {
+        self.0
+    }
 }
 
 impl FromStr for Amount {

--- a/modules/src/clients/host_functions.rs
+++ b/modules/src/clients/host_functions.rs
@@ -78,9 +78,10 @@ where
 }
 
 // implementation for tendermint functions
-impl<T> tendermint_light_client_verifier::host_functions::HostFunctionsProvider for HostFunctionsManager<T>
-    where
-        T: HostFunctionsProvider,
+impl<T> tendermint_light_client_verifier::host_functions::HostFunctionsProvider
+    for HostFunctionsManager<T>
+where
+    T: HostFunctionsProvider,
 {
     fn sha2_256(preimage: &[u8]) -> [u8; 32] {
         T::sha256_digest(preimage)
@@ -99,8 +100,8 @@ impl<T> tendermint_light_client_verifier::host_functions::HostFunctionsProvider 
 
 // implementation for ics23
 impl<H> ics23::HostFunctionsProvider for HostFunctionsManager<H>
-    where
-        H: HostFunctionsProvider,
+where
+    H: HostFunctionsProvider,
 {
     fn sha2_256(message: &[u8]) -> [u8; 32] {
         H::sha2_256(message)

--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -1,12 +1,12 @@
 use core::convert::TryInto;
 use core::fmt::Debug;
 
+use crate::clients::host_functions::{HostFunctionsManager, HostFunctionsProvider};
 use ibc_proto::ibc::core::commitment::v1::MerkleProof as RawMerkleProof;
 use prost::Message;
 use tendermint_light_client_verifier::types::{TrustedBlockState, UntrustedBlockState};
 use tendermint_light_client_verifier::{ProdVerifier, Verdict, Verifier};
 use tendermint_proto::Protobuf;
-use crate::clients::host_functions::{HostFunctionsManager, HostFunctionsProvider};
 
 use crate::clients::ics07_tendermint::client_state::ClientState;
 use crate::clients::ics07_tendermint::consensus_state::ConsensusState;
@@ -43,8 +43,8 @@ pub struct TendermintClient<H: HostFunctionsProvider> {
 }
 
 impl<H> ClientDef for TendermintClient<H>
-    where
-        H: HostFunctionsProvider
+where
+    H: HostFunctionsProvider,
 {
     type Header = Header;
     type ClientState = ClientState;
@@ -482,8 +482,9 @@ fn verify_membership<H, P>(
     path: P,
     value: Vec<u8>,
 ) -> Result<(), Ics02Error>
-    where
-        H: HostFunctionsProvider, P: Into<Path>,
+where
+    H: HostFunctionsProvider,
+    P: Into<Path>,
 {
     let merkle_path = apply_prefix(prefix, vec![path.into().to_string()]);
     let merkle_proof: MerkleProof<H> = RawMerkleProof::try_from(proof.clone())
@@ -508,8 +509,9 @@ fn verify_non_membership<H, P>(
     root: &CommitmentRoot,
     path: P,
 ) -> Result<(), Ics02Error>
-    where
-        H: HostFunctionsProvider, P: Into<Path>,
+where
+    H: HostFunctionsProvider,
+    P: Into<Path>,
 {
     let merkle_path = apply_prefix(prefix, vec![path.into().to_string()]);
     let merkle_proof: MerkleProof<H> = RawMerkleProof::try_from(proof.clone())

--- a/modules/src/core/ics02_client/client_def.rs
+++ b/modules/src/core/ics02_client/client_def.rs
@@ -218,7 +218,9 @@ pub enum AnyClient<HostFunctions: HostFunctionsProvider> {
 impl<HostFunctions: HostFunctionsProvider> AnyClient<HostFunctions> {
     pub fn from_client_type(client_type: ClientType) -> Self {
         match client_type {
-            ClientType::Tendermint => Self::Tendermint(TendermintClient::<HostFunctions>::default()),
+            ClientType::Tendermint => {
+                Self::Tendermint(TendermintClient::<HostFunctions>::default())
+            }
             ClientType::Beefy => Self::Beefy(BeefyClient::<HostFunctions>::default()),
             ClientType::Near => Self::Near(BeefyClient::<HostFunctions>::default()),
             #[cfg(any(test, feature = "mocks"))]

--- a/modules/src/test_utils.rs
+++ b/modules/src/test_utils.rs
@@ -143,6 +143,50 @@ impl HostFunctionsProvider for Crypto {
     fn sha256_digest(data: &[u8]) -> [u8; 32] {
         sp_io::hashing::sha2_256(data)
     }
+
+    fn sha2_256(message: &[u8]) -> [u8; 32] {
+        sp_io::hashing::sha2_256(message)
+    }
+
+    fn sha2_512(message: &[u8]) -> [u8; 64] {
+        use sha2::Digest;
+        let mut hasher = sha2::Sha512::new();
+        hasher.update(message);
+        let hash = hasher.finalize();
+        let mut res = [0u8; 64];
+        res.copy_from_slice(&hash);
+        res
+    }
+
+    fn sha2_512_truncated(message: &[u8]) -> [u8; 32] {
+        use sha2::Digest;
+        let mut hasher = sha2::Sha512::new();
+        hasher.update(message);
+        let hash = hasher.finalize();
+        let mut res = [0u8; 32];
+        res.copy_from_slice(&hash[..32]);
+        res
+    }
+
+    fn sha3_512(message: &[u8]) -> [u8; 64] {
+        use sha3::Digest;
+        let mut hasher = sha3::Sha3_512::new();
+        hasher.update(message);
+        let hash = hasher.finalize();
+        let mut res = [0u8; 64];
+        res.copy_from_slice(&hash);
+        res
+    }
+
+    fn ripemd160(message: &[u8]) -> [u8; 20] {
+        use ripemd::Digest;
+        let mut hasher = ripemd::Ripemd160::new();
+        hasher.update(message);
+        let hash = hasher.finalize();
+        let mut res = [0u8; 20];
+        res.copy_from_slice(&hash);
+        res
+    }
 }
 
 impl Ics20Keeper for DummyTransferModule {


### PR DESCRIPTION
Adds a function to expose the inner U256 value in the `Amount` struct used in ics20.
This is necessary to allow users to convert the amount to other types such as `u128`.

Also fixes tests by implementing the missing host functions.