### PR TITLE
attempt to feature gate substrate libs for beefy

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -36,6 +36,7 @@ clock = ["tendermint/clock", "time/std"]
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.
 # Depends on the `testgen` suite for generating Tendermint light blocks.
 mocks = ["tendermint-testgen", "clock", "std", "sp-io", "sp-io/std", "sha3", "ripemd"]
+ics11-beefy = ["tendermint-testgen", "clock", "std", "sp-io", "sp-core", "sp-std", "sp-io/std", "sha3", "ripemd"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
@@ -58,16 +59,17 @@ num-traits = { version = "0.2.15", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 uint = { version = "0.9", default-features = false }
 beefy-client = { package = "beefy-generic-client",  git = "https://github.com/ComposableFi/beefy-client", branch = "master", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 pallet-mmr-primitives = { package = "sp-mmr-primitives", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 beefy-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false, optional = true }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false, optional = true}
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false, optional = true }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false, optional = true }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false, optional = true }
 sha3 = { version = "0.10.1", optional = true }
 ripemd = { version = "0.1.1", optional = true }
+
 
 [dependencies.tendermint]
 git = "https://github.com/composableFi/tendermint-rs"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -36,7 +36,7 @@ clock = ["tendermint/clock", "time/std"]
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.
 # Depends on the `testgen` suite for generating Tendermint light blocks.
 mocks = ["tendermint-testgen", "clock", "std", "sp-io", "sp-io/std", "sha3", "ripemd"]
-ics11-beefy = ["tendermint-testgen", "clock", "std", "sp-io", "sp-core", "sp-std", "sp-io/std", "sha3", "ripemd"]
+ics11-beefy = ["sp-io", "sp-core", "sp-std"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.

--- a/modules/src/clients/host_functions.rs
+++ b/modules/src/clients/host_functions.rs
@@ -1,7 +1,6 @@
 use crate::core::ics02_client::error::Error;
 use crate::prelude::*;
 use core::marker::PhantomData;
-use sp_core::H256;
 
 /// This trait captures all the functions that the host chain should provide for
 /// crypto operations.
@@ -21,7 +20,7 @@ pub trait HostFunctionsProvider: Clone + Send + Sync + Default {
     /// This function should verify membership in a trie proof using parity's sp-trie package
     /// with a BlakeTwo256 Hasher
     fn verify_membership_trie_proof(
-        root: &H256,
+        root: &[u8; 32],
         proof: &[Vec<u8>],
         key: &[u8],
         value: &[u8],
@@ -30,7 +29,7 @@ pub trait HostFunctionsProvider: Clone + Send + Sync + Default {
     /// This function should verify non membership in a trie proof using parity's sp-trie package
     /// with a BlakeTwo256 Hasher
     fn verify_non_membership_trie_proof(
-        root: &H256,
+        root: &[u8; 32],
         proof: &[Vec<u8>],
         key: &[u8],
     ) -> Result<(), Error>;

--- a/modules/src/clients/ics11_beefy/client_def.rs
+++ b/modules/src/clients/ics11_beefy/client_def.rs
@@ -411,7 +411,7 @@ fn verify_membership<HostFunctions: HostFunctionsProvider, P: Into<Path>>(
     let trie_proof: Vec<Vec<u8>> = codec::Decode::decode(&mut &*trie_proof)
         .map_err(|e| Error::beefy(BeefyError::scale_decode(e)))?;
     let root = H256::from_slice(root.as_bytes());
-    HostFunctions::verify_membership_trie_proof(&root, &trie_proof, &key, &value)
+    HostFunctions::verify_membership_trie_proof(root.as_fixed_bytes(), &trie_proof, &key, &value)
 }
 
 fn verify_non_membership<HostFunctions: HostFunctionsProvider, P: Into<Path>>(
@@ -431,7 +431,7 @@ fn verify_non_membership<HostFunctions: HostFunctionsProvider, P: Into<Path>>(
     let trie_proof: Vec<Vec<u8>> = codec::Decode::decode(&mut &*trie_proof)
         .map_err(|e| Error::beefy(BeefyError::scale_decode(e)))?;
     let root = H256::from_slice(root.as_bytes());
-    HostFunctions::verify_non_membership_trie_proof(&root, &trie_proof, &key)
+    HostFunctions::verify_non_membership_trie_proof(root.as_fixed_bytes(), &trie_proof, &key)
 }
 
 fn verify_delay_passed(

--- a/modules/src/clients/ics11_beefy/header.rs
+++ b/modules/src/clients/ics11_beefy/header.rs
@@ -405,7 +405,7 @@ pub fn decode_timestamp_extrinsic<HostFunctions: HostFunctionsProvider>(
     // Timestamp extrinsic should be the first inherent and hence the first extrinsic
     // https://github.com/paritytech/substrate/blob/d602397a0bbb24b5d627795b797259a44a5e29e9/primitives/trie/src/lib.rs#L99-L101
     let key = codec::Encode::encode(&Compact(0u32));
-    HostFunctions::verify_membership_trie_proof(&extrinsic_root, proof, &*key, ext)
+    HostFunctions::verify_membership_trie_proof(extrinsic_root.as_fixed_bytes(), proof, &*key, ext)
         .map_err(|e| Error::timestamp_extrinsic(format!("Proof Verification failed {:?}", e)))?;
     // Decoding from the [2..] because the timestamp inmherent has two extra bytes before the call that represents the
     // call length and the extrinsic version.

--- a/modules/src/clients/mod.rs
+++ b/modules/src/clients/mod.rs
@@ -2,5 +2,7 @@
 
 pub mod host_functions;
 pub mod ics07_tendermint;
+#[cfg(any(test, feature = "ics11_beefy"))]
 pub mod ics11_beefy;
+#[cfg(any(test, feature = "ics11_beefy"))]
 pub mod ics13_near;

--- a/modules/src/core/ics02_client/client_def.rs
+++ b/modules/src/core/ics02_client/client_def.rs
@@ -1,5 +1,6 @@
 use crate::clients::host_functions::HostFunctionsProvider;
 use crate::clients::ics07_tendermint::client_def::TendermintClient;
+#[cfg(any(test, feature = "ics11_beefy"))]
 use crate::clients::ics11_beefy::client_def::BeefyClient;
 use crate::core::ics02_client::client_consensus::{AnyConsensusState, ConsensusState};
 use crate::core::ics02_client::client_state::{AnyClientState, ClientState};
@@ -209,7 +210,9 @@ pub trait ClientDef: Clone {
 #[derive(Clone, Debug)]
 pub enum AnyClient<HostFunctions: HostFunctionsProvider> {
     Tendermint(TendermintClient<HostFunctions>),
+    #[cfg(any(test, feature = "ics11_beefy"))]
     Beefy(BeefyClient<HostFunctions>),
+    #[cfg(any(test, feature = "ics11_beefy"))]
     Near(BeefyClient<HostFunctions>),
     #[cfg(any(test, feature = "mocks"))]
     Mock(MockClient),
@@ -221,7 +224,9 @@ impl<HostFunctions: HostFunctionsProvider> AnyClient<HostFunctions> {
             ClientType::Tendermint => {
                 Self::Tendermint(TendermintClient::<HostFunctions>::default())
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             ClientType::Beefy => Self::Beefy(BeefyClient::<HostFunctions>::default()),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             ClientType::Near => Self::Near(BeefyClient::<HostFunctions>::default()),
             #[cfg(any(test, feature = "mocks"))]
             ClientType::Mock => Self::Mock(MockClient::default()),
@@ -254,6 +259,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 client.verify_header(ctx, client_id, client_state, header)
             }
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(client) => {
                 let (client_state, header) = downcast!(
                     client_state => AnyClientState::Beefy,
@@ -264,6 +270,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 client.verify_header(ctx, client_id, client_state, header)
             }
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => {
                 // let (client_state, header) = downcast!(
                 //     client_state => AnyClientState::Beefy,
@@ -309,7 +316,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
 
                 Ok((AnyClientState::Tendermint(new_state), new_consensus))
             }
-
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(client) => {
                 let (client_state, header) = downcast!(
                     client_state => AnyClientState::Beefy,
@@ -322,6 +329,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
 
                 Ok((AnyClientState::Beefy(new_state), new_consensus))
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => {
                 todo!()
             }
@@ -357,6 +365,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 let client_state = client.update_state_on_misbehaviour(client_state, header)?;
                 Ok(Self::ClientState::Tendermint(client_state))
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClient::Beefy(client) => {
                 let (client_state, header) = downcast!(
                     client_state => AnyClientState::Beefy,
@@ -367,6 +376,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 let client_state = client.update_state_on_misbehaviour(client_state, header)?;
                 Ok(Self::ClientState::Beefy(client_state))
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClient::Near(_) => {
                 todo!()
             }
@@ -401,6 +411,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 .ok_or_else(|| Error::client_args_type_mismatch(ClientType::Tendermint))?;
                 client.check_for_misbehaviour(ctx, client_id, client_state, header)
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClient::Beefy(client) => {
                 let (client_state, header) = downcast!(
                     client_state => AnyClientState::Beefy,
@@ -410,6 +421,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
 
                 client.check_for_misbehaviour(ctx, client_id, client_state, header)
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClient::Near(_) => {
                 todo!()
             }
@@ -451,6 +463,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 Ok((AnyClientState::Tendermint(new_state), new_consensus))
             }
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(client) => {
                 let (client_state, consensus_state) = downcast!(
                     client_state => AnyClientState::Beefy,
@@ -468,6 +481,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 Ok((AnyClientState::Beefy(new_state), new_consensus))
             }
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => {
                 todo!()
             }
@@ -524,6 +538,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 )
             }
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(client) => {
                 let client_state = downcast!(
                     client_state => AnyClientState::Beefy
@@ -542,6 +557,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                     expected_consensus_state,
                 )
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => {
                 todo!()
             }
@@ -596,6 +612,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                     expected_connection_end,
                 )
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(client) => {
                 let client_state = downcast!(client_state => AnyClientState::Beefy)
                     .ok_or_else(|| Error::client_args_type_mismatch(ClientType::Beefy))?;
@@ -612,6 +629,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                     expected_connection_end,
                 )
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => {
                 todo!()
             }
@@ -667,6 +685,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 )
             }
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(client) => {
                 let client_state = downcast!(client_state => AnyClientState::Beefy)
                     .ok_or_else(|| Error::client_args_type_mismatch(ClientType::Beefy))?;
@@ -684,6 +703,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                     expected_channel_end,
                 )
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => {
                 todo!()
             }
@@ -737,6 +757,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                     client_state_on_counterparty,
                 )
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(client) => {
                 let client_state = downcast!(
                     client_state => AnyClientState::Beefy
@@ -754,6 +775,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                     client_state_on_counterparty,
                 )
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => {
                 todo!()
             }
@@ -814,6 +836,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 )
             }
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(client) => {
                 let client_state = downcast!(
                     client_state => AnyClientState::Beefy
@@ -834,6 +857,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                     commitment,
                 )
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => {
                 todo!()
             }
@@ -897,6 +921,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 )
             }
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(client) => {
                 let client_state = downcast!(
                     client_state => AnyClientState::Beefy
@@ -917,6 +942,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                     ack_commitment,
                 )
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => {
                 todo!()
             }
@@ -977,6 +1003,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 )
             }
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(client) => {
                 let client_state = downcast!(
                     client_state => AnyClientState::Beefy
@@ -996,6 +1023,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                     sequence,
                 )
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => {
                 todo!()
             }
@@ -1056,6 +1084,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                 )
             }
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(client) => {
                 let client_state = downcast!(
                     client_state => AnyClientState::Beefy
@@ -1075,6 +1104,7 @@ impl<HostFunctions: HostFunctionsProvider> ClientDef for AnyClient<HostFunctions
                     sequence,
                 )
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => {
                 todo!()
             }

--- a/modules/src/core/ics02_client/client_state.rs
+++ b/modules/src/core/ics02_client/client_state.rs
@@ -8,6 +8,7 @@ use tendermint_proto::Protobuf;
 use ibc_proto::ibc::core::client::v1::IdentifiedClientState;
 
 use crate::clients::ics07_tendermint::client_state;
+#[cfg(any(test, feature = "ics11_beefy"))]
 use crate::clients::ics11_beefy::client_state as beefy_client_state;
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::Error;
@@ -63,6 +64,7 @@ pub trait ClientState: Clone + core::fmt::Debug + Send + Sync {
 #[serde(tag = "type")]
 pub enum AnyUpgradeOptions {
     Tendermint(client_state::UpgradeOptions),
+    #[cfg(any(test, feature = "ics11_beefy"))]
     Beefy(beefy_client_state::UpgradeOptions),
     #[cfg(any(test, feature = "mocks"))]
     Mock(()),
@@ -72,6 +74,7 @@ impl AnyUpgradeOptions {
     fn into_tendermint(self) -> client_state::UpgradeOptions {
         match self {
             Self::Tendermint(options) => options,
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(_) => {
                 panic!("cannot downcast AnyUpgradeOptions::Beefy to Tendermint::UpgradeOptions")
             }
@@ -82,11 +85,13 @@ impl AnyUpgradeOptions {
         }
     }
 
+    #[cfg(any(test, feature = "ics11_beefy"))]
     fn into_beefy(self) -> beefy_client_state::UpgradeOptions {
         match self {
             Self::Tendermint(_) => {
                 panic!("cannot downcast AnyUpgradeOptions::Tendermint to Beefy::UpgradeOptions")
             }
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(options) => options,
             #[cfg(any(test, feature = "mocks"))]
             Self::Mock(_) => {
@@ -100,8 +105,10 @@ impl AnyUpgradeOptions {
 #[serde(tag = "type")]
 pub enum AnyClientState {
     Tendermint(client_state::ClientState),
+    #[cfg(any(test, feature = "ics11_beefy"))]
     #[serde(skip)]
     Beefy(beefy_client_state::ClientState),
+    #[cfg(any(test, feature = "ics11_beefy"))]
     #[serde(skip)]
     Near(beefy_client_state::ClientState),
     #[cfg(any(test, feature = "mocks"))]
@@ -112,7 +119,9 @@ impl AnyClientState {
     pub fn latest_height(&self) -> Height {
         match self {
             Self::Tendermint(tm_state) => tm_state.latest_height(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(bf_state) => bf_state.latest_height(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => todo!(),
             #[cfg(any(test, feature = "mocks"))]
             Self::Mock(mock_state) => mock_state.latest_height(),
@@ -122,7 +131,9 @@ impl AnyClientState {
     pub fn frozen_height(&self) -> Option<Height> {
         match self {
             Self::Tendermint(tm_state) => tm_state.frozen_height(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(bf_state) => bf_state.frozen_height(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => todo!(),
             #[cfg(any(test, feature = "mocks"))]
             Self::Mock(mock_state) => mock_state.frozen_height(),
@@ -132,7 +143,9 @@ impl AnyClientState {
     pub fn trust_threshold(&self) -> Option<TrustThreshold> {
         match self {
             AnyClientState::Tendermint(state) => Some(state.trust_level),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClientState::Beefy(_) => None,
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => todo!(),
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(_) => None,
@@ -142,7 +155,9 @@ impl AnyClientState {
     pub fn max_clock_drift(&self) -> Duration {
         match self {
             AnyClientState::Tendermint(state) => state.max_clock_drift,
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClientState::Beefy(_) => Duration::new(0, 0),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => todo!(),
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(_) => Duration::new(0, 0),
@@ -152,7 +167,9 @@ impl AnyClientState {
     pub fn client_type(&self) -> ClientType {
         match self {
             Self::Tendermint(state) => state.client_type(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(state) => state.client_type(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => todo!(),
             #[cfg(any(test, feature = "mocks"))]
             Self::Mock(state) => state.client_type(),
@@ -162,7 +179,9 @@ impl AnyClientState {
     pub fn refresh_period(&self) -> Option<Duration> {
         match self {
             AnyClientState::Tendermint(tm_state) => tm_state.refresh_time(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClientState::Beefy(_) => None,
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => None,
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(mock_state) => mock_state.refresh_time(),
@@ -172,7 +191,9 @@ impl AnyClientState {
     pub fn expired(&self, elapsed_since_latest: Duration) -> bool {
         match self {
             AnyClientState::Tendermint(tm_state) => tm_state.expired(elapsed_since_latest),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClientState::Beefy(_) => false,
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near(_) => false,
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(mock_state) => mock_state.expired(elapsed_since_latest),
@@ -194,6 +215,7 @@ impl TryFrom<Any> for AnyClientState {
                     .map_err(Error::decode_raw_client_state)?,
             )),
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             BEEFY_CLIENT_STATE_TYPE_URL => Ok(AnyClientState::Beefy(
                 beefy_client_state::ClientState::decode_vec(&raw.value)
                     .map_err(Error::decode_raw_client_state)?,
@@ -218,12 +240,14 @@ impl From<AnyClientState> for Any {
                     .encode_vec()
                     .expect("encoding to `Any` from `AnyClientState::Tendermint`"),
             },
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClientState::Beefy(value) => Any {
                 type_url: BEEFY_CLIENT_STATE_TYPE_URL.to_string(),
                 value: value
                     .encode_vec()
                     .expect("encoding to `Any` from `AnyClientState::Tendermint`"),
             },
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClientState::Near(_) => Any {
                 type_url: BEEFY_CLIENT_STATE_TYPE_URL.to_string(),
                 value: value
@@ -247,7 +271,9 @@ impl ClientState for AnyClientState {
     fn chain_id(&self) -> ChainId {
         match self {
             AnyClientState::Tendermint(tm_state) => tm_state.chain_id(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClientState::Beefy(bf_state) => bf_state.chain_id(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClientState::Near(_) => todo!(),
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(mock_state) => mock_state.chain_id(),
@@ -276,9 +302,11 @@ impl ClientState for AnyClientState {
             AnyClientState::Tendermint(tm_state) => tm_state
                 .upgrade(upgrade_height, upgrade_options.into_tendermint(), chain_id)
                 .wrap_any(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClientState::Beefy(bf_state) => bf_state
                 .upgrade(upgrade_height, upgrade_options.into_beefy(), chain_id)
                 .wrap_any(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyClientState::Near(near_state) => near_state
                 .upgrade(upgrade_height, upgrade_options.into_beefy(), chain_id)
                 .wrap_any(),

--- a/modules/src/core/ics02_client/client_type.rs
+++ b/modules/src/core/ics02_client/client_type.rs
@@ -8,7 +8,9 @@ use super::error::Error;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum ClientType {
     Tendermint = 1,
+    #[cfg(any(test, feature = "ics11_beefy"))]
     Beefy = 2,
+    #[cfg(any(test, feature = "ics11_beefy"))]
     Near = 3,
     #[cfg(any(test, feature = "mocks"))]
     Mock = 9999,
@@ -26,7 +28,9 @@ impl ClientType {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Tendermint => Self::TENDERMINT_STR,
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy => Self::BEEFY_STR,
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Near => Self::NEAR_STR,
             #[cfg(any(test, feature = "mocks"))]
             Self::Mock => Self::MOCK_STR,
@@ -46,6 +50,7 @@ impl core::str::FromStr for ClientType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             Self::TENDERMINT_STR => Ok(Self::Tendermint),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::BEEFY_STR => Ok(Self::Beefy),
             #[cfg(any(test, feature = "mocks"))]
             Self::MOCK_STR => Ok(Self::Mock),

--- a/modules/src/core/ics02_client/client_type.rs
+++ b/modules/src/core/ics02_client/client_type.rs
@@ -18,7 +18,9 @@ pub enum ClientType {
 
 impl ClientType {
     const TENDERMINT_STR: &'static str = "07-tendermint";
+    #[cfg(any(test, feature = "ics11_beefy"))]
     const BEEFY_STR: &'static str = "11-beefy";
+    #[cfg(any(test, feature = "ics11_beefy"))]
     const NEAR_STR: &'static str = "11-beefy";
 
     #[cfg_attr(not(test), allow(dead_code))]

--- a/modules/src/core/ics02_client/error.rs
+++ b/modules/src/core/ics02_client/error.rs
@@ -5,7 +5,9 @@ use tendermint::Error as TendermintError;
 use tendermint_proto::Error as TendermintProtoError;
 
 use crate::clients::ics07_tendermint::error::Error as Ics07Error;
+#[cfg(any(test, feature = "ics11_beefy"))]
 use crate::clients::ics11_beefy::error::Error as Ics11Error;
+#[cfg(any(test, feature = "ics11_beefy"))]
 use crate::clients::ics13_near::error::Error as Ics13Error;
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::height::HeightError;
@@ -16,6 +18,270 @@ use crate::signer::SignerError;
 use crate::timestamp::Timestamp;
 use crate::Height;
 
+#[cfg(not(any(test, feature = "ics11_beefy")))]
+define_error! {
+    #[derive(Debug, PartialEq, Eq)]
+    Error {
+        UnknownClientType
+            { client_type: String }
+            | e | { format_args!("unknown client type: {0}", e.client_type) },
+
+        ClientIdentifierConstructor
+            { client_type: ClientType, counter: u64 }
+            [ ValidationError ]
+            | e | {
+                format_args!("Client identifier constructor failed for type {0} with counter {1}",
+                    e.client_type, e.counter)
+            },
+
+        ClientAlreadyExists
+            { client_id: ClientId }
+            | e | { format_args!("client already exists: {0}", e.client_id) },
+
+        ClientNotFound
+            { client_id: ClientId }
+            | e | { format_args!("client not found: {0}", e.client_id) },
+
+        ClientFrozen
+            { client_id: ClientId }
+            | e | { format_args!("client is frozen: {0}", e.client_id) },
+
+        ConsensusStateNotFound
+            { client_id: ClientId, height: Height }
+            | e | {
+                format_args!("consensus state not found at: {0} at height {1}",
+                    e.client_id, e.height)
+            },
+
+        ImplementationSpecific
+            { reason: String }
+            | e | { format_args!("implementation specific error: {}", e.reason) },
+
+        HeaderVerificationFailure
+            { reason: String }
+            | e | { format_args!("header verification failed with reason: {}", e.reason) },
+
+        InvalidTrustThreshold
+            { numerator: u64, denominator: u64 }
+            | e | { format_args!("failed to build trust threshold from fraction: {}/{}", e.numerator, e.denominator) },
+
+        FailedTrustThresholdConversion
+            { numerator: u64, denominator: u64 }
+            [ TendermintError ]
+            | e | { format_args!("failed to build Tendermint domain type trust threshold from fraction: {}/{}", e.numerator, e.denominator) },
+
+        UnknownClientStateType
+            { client_state_type: String }
+            | e | { format_args!("unknown client state type: {0}", e.client_state_type) },
+
+        EmptyClientStateResponse
+            | _ | { "the client state was not found" },
+
+        EmptyPrefix
+            | _ | { "empty prefix" },
+
+        UnknownConsensusStateType
+            { consensus_state_type: String }
+            | e | {
+                format_args!("unknown client consensus state type: {0}",
+                    e.consensus_state_type)
+            },
+
+        EmptyConsensusStateResponse
+            | _ | { "the client consensus state was not found" },
+
+        UnknownHeaderType
+            { header_type: String }
+            | e | {
+                format_args!("unknown header type: {0}",
+                    e.header_type)
+            },
+
+        UnknownMisbehaviourType
+            { misbehavior_type: String }
+            | e | {
+                format_args!("unknown misbehaviour type: {0}",
+                    e.misbehavior_type)
+            },
+
+        InvalidRawClientId
+            { client_id: String }
+            [ ValidationError ]
+            | e | {
+                format_args!("invalid raw client identifier {0}",
+                    e.client_id)
+            },
+
+        DecodeRawClientState
+            [ TraceError<TendermintProtoError> ]
+            | _ | { "error decoding raw client state" },
+
+        MissingRawClientState
+            | _ | { "missing raw client state" },
+
+        InvalidRawConsensusState
+            [ TraceError<TendermintProtoError> ]
+            | _ | { "invalid raw client consensus state" },
+
+        MissingRawConsensusState
+            | _ | { "missing raw client consensus state" },
+
+        InvalidMsgUpdateClientId
+            [ ValidationError ]
+            | _ | { "invalid client id in the update client message" },
+
+        Decode
+            [ TraceError<prost::DecodeError> ]
+            | _ | { "decode error" },
+
+        MissingHeight
+            | _ | { "invalid raw client consensus state: the height field is missing" },
+
+        InvalidClientIdentifier
+            [ ValidationError ]
+            | _ | { "invalid client identifier" },
+
+        InvalidRawHeader
+            [ TraceError<TendermintProtoError> ]
+            | _ | { "invalid raw header" },
+
+        MissingRawHeader
+            | _ | { "missing raw header" },
+
+        DecodeRawMisbehaviour
+            [ TraceError<TendermintProtoError> ]
+            | _ | { "invalid raw misbehaviour" },
+
+        InvalidRawMisbehaviour
+            [ ValidationError ]
+            | _ | { "invalid raw misbehaviour" },
+
+        MissingRawMisbehaviour
+            | _ | { "missing raw misbehaviour" },
+
+        InvalidStringAsHeight
+            { value: String }
+            [ HeightError ]
+            | e | { format_args!("String {0} cannnot be converted to height", e.value) },
+
+        InvalidHeightResult
+            | _ | { "height cannot end up zero or negative" },
+
+        InvalidAddress
+            | _ | { "invalid address" },
+
+        InvalidUpgradeClientProof
+            [ Ics23Error ]
+            | _ | { "invalid proof for the upgraded client state" },
+
+        InvalidUpgradeConsensusStateProof
+            [ Ics23Error ]
+            | _ | { "invalid proof for the upgraded consensus state" },
+
+        InvalidCommitmentProof
+            [ Ics23Error ]
+            | _ | { "invalid commitment proof bytes" },
+
+        Tendermint
+            [ Ics07Error ]
+            | _ | { "tendermint error" },
+
+        InvalidPacketTimestamp
+            [ crate::timestamp::ParseTimestampError ]
+            | _ | { "invalid packet timeout timestamp value" },
+
+        ClientArgsTypeMismatch
+            { client_type: ClientType }
+            | e | {
+                format_args!("mismatch between client and arguments types, expected: {0:?}",
+                    e.client_type)
+            },
+
+        InsufficientVotingPower
+            { reason: String }
+            | e | {
+                format_args!("Insufficient overlap {}", e.reason)
+            },
+
+        RawClientAndConsensusStateTypesMismatch
+            {
+                state_type: ClientType,
+                consensus_type: ClientType,
+            }
+            | e | {
+                format_args!("mismatch in raw client consensus state {} with expected state {}",
+                    e.state_type, e.consensus_type)
+            },
+
+        LowHeaderHeight
+            {
+                header_height: Height,
+                latest_height: Height
+            }
+            | e | {
+                format!("received header height ({:?}) is lower than (or equal to) client latest height ({:?})",
+                    e.header_height, e.latest_height)
+            },
+
+        LowUpgradeHeight
+            {
+                upgraded_height: Height,
+                client_height: Height,
+            }
+            | e | {
+                format_args!("upgraded client height {} must be at greater than current client height {}",
+                    e.upgraded_height, e.client_height)
+            },
+
+        InvalidConsensusStateTimestamp
+            {
+                time1: Timestamp,
+                time2: Timestamp,
+            }
+            | e | {
+                format_args!("timestamp is invalid or missing, timestamp={0},  now={1}", e.time1, e.time2)
+            },
+
+        HeaderNotWithinTrustPeriod
+            {
+                latest_time:Timestamp,
+                update_time: Timestamp,
+            }
+            | e | {
+                format_args!("header not withing trusting period: expires_at={0} now={1}", e.latest_time, e.update_time)
+            },
+
+        TendermintHandlerError
+            [ Ics07Error ]
+            | _ | { format_args!("Tendermint-specific handler error") },
+
+        MissingLocalConsensusState
+            { height: Height }
+            | e | { format_args!("the local consensus state could not be retrieved for height {}", e.height) },
+
+        InvalidConnectionEnd
+            [ TraceError<TendermintProtoError>]
+            | _ | { "invalid connection end" },
+
+        InvalidChannelEnd
+            [ TraceError<TendermintProtoError>]
+            | _ | { "invalid channel end" },
+
+        InvalidAnyClientState
+            [ TraceError<TendermintProtoError>]
+            | _ | { "invalid any client state" },
+
+        InvalidAnyConsensusState
+            [ TraceError<TendermintProtoError> ]
+            | _ | { "invalid any client consensus state" },
+
+        Signer
+            [ SignerError ]
+            | _ | { "failed to parse signer" },
+    }
+}
+
+#[cfg(any(test, feature = "ics11_beefy"))]
 define_error! {
     #[derive(Debug, PartialEq, Eq)]
     Error {
@@ -292,12 +558,14 @@ impl From<Ics07Error> for Error {
     }
 }
 
+#[cfg(any(test, feature = "ics11_beefy"))]
 impl From<Ics11Error> for Error {
     fn from(e: Ics11Error) -> Error {
         Error::beefy(e)
     }
 }
 
+#[cfg(any(test, feature = "ics11_beefy"))]
 impl From<Ics13Error> for Error {
     fn from(e: Ics13Error) -> Error {
         Error::near(e)

--- a/modules/src/core/ics02_client/handler/update_client.rs
+++ b/modules/src/core/ics02_client/handler/update_client.rs
@@ -1,10 +1,10 @@
 //! Protocol logic specific to processing ICS2 messages of type `MsgUpdateAnyClient`.
 use core::fmt::Debug;
-use tracing::debug;
 
 use crate::clients::host_functions::HostFunctionsProvider;
 use crate::core::ics02_client::client_def::{AnyClient, ClientDef, ConsensusUpdateResult};
 use crate::core::ics02_client::client_state::{AnyClientState, ClientState};
+#[cfg(any(test, feature = "ics11_beefy"))]
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::events::Attributes;

--- a/modules/src/core/ics02_client/handler/update_client.rs
+++ b/modules/src/core/ics02_client/handler/update_client.rs
@@ -53,6 +53,7 @@ pub fn process<HostFunctions: HostFunctionsProvider>(
         return Err(Error::client_frozen(client_id));
     }
 
+    #[cfg(any(test, feature = "ics11_beefy"))]
     if client_type != ClientType::Beefy {
         // Read consensus state from the host chain store.
         let latest_consensus_state = ctx

--- a/modules/src/core/ics02_client/header.rs
+++ b/modules/src/core/ics02_client/header.rs
@@ -6,6 +6,7 @@ use subtle_encoding::hex;
 use tendermint_proto::Protobuf;
 
 use crate::clients::ics07_tendermint::header::{decode_header, Header as TendermintHeader};
+#[cfg(any(test, feature = "ics11_beefy"))]
 use crate::clients::ics11_beefy::header::{decode_header as decode_beefy_header, BeefyHeader};
 // use crate::clients::ics13_near::header::NearHeader;
 use crate::core::ics02_client::client_type::ClientType;
@@ -35,6 +36,7 @@ pub trait Header: Clone + core::fmt::Debug + Send + Sync {
 pub enum AnyHeader {
     Tendermint(TendermintHeader),
     #[serde(skip)]
+    #[cfg(any(test, feature = "ics11_beefy"))]
     Beefy(BeefyHeader),
     // #[serde(skip)]
     // Near(NearHeader),
@@ -46,6 +48,7 @@ impl AnyHeader {
     pub fn height(&self) -> Height {
         match self {
             Self::Tendermint(header) => header.height(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(_header) => Default::default(),
             // Self::Near(_header) => Default::default(),
             #[cfg(any(test, feature = "mocks"))]
@@ -56,6 +59,7 @@ impl AnyHeader {
     pub fn timestamp(&self) -> Timestamp {
         match self {
             Self::Tendermint(header) => header.timestamp(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(_header) => Default::default(),
             // Self::Near(_header) => Default::default(),
             #[cfg(any(test, feature = "mocks"))]
@@ -68,6 +72,7 @@ impl Header for AnyHeader {
     fn client_type(&self) -> ClientType {
         match self {
             Self::Tendermint(header) => header.client_type(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             Self::Beefy(header) => header.client_type(),
             // Self::Near(header) => header.client_type(),
             #[cfg(any(test, feature = "mocks"))]
@@ -106,6 +111,7 @@ impl TryFrom<Any> for AnyHeader {
                 Ok(AnyHeader::Tendermint(val))
             }
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             BEEFY_HEADER_TYPE_URL => {
                 let val = decode_beefy_header(&*raw.value).map_err(Error::beefy)?;
                 Ok(AnyHeader::Beefy(val))
@@ -131,6 +137,7 @@ impl From<AnyHeader> for Any {
                     .expect("encoding to `Any` from `AnyHeader::Tendermint`"),
             },
 
+            #[cfg(any(test, feature = "ics11_beefy"))]
             AnyHeader::Beefy(header) => Any {
                 type_url: BEEFY_HEADER_TYPE_URL.to_string(),
                 value: header

--- a/modules/src/core/ics23_commitment/merkle.rs
+++ b/modules/src/core/ics23_commitment/merkle.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
+#[cfg(any(test, feature = "ics11_beefy"))]
 use sp_std::marker::PhantomData;
+#[cfg(not(any(test, feature = "ics11_beefy")))]
+use std::marker::PhantomData;
 use tendermint::merkle::proof::Proof as TendermintProof;
 
 use crate::clients::host_functions::{HostFunctionsManager, HostFunctionsProvider};

--- a/modules/src/core/ics24_host/identifier.rs
+++ b/modules/src/core/ics24_host/identifier.rs
@@ -171,7 +171,9 @@ impl ClientId {
     pub fn prefix(client_type: ClientType) -> &'static str {
         match client_type {
             ClientType::Tendermint => ClientType::Tendermint.as_str(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             ClientType::Beefy => ClientType::Beefy.as_str(),
+            #[cfg(any(test, feature = "ics11_beefy"))]
             ClientType::Near => ClientType::Near.as_str(),
             #[cfg(any(test, feature = "mocks"))]
             ClientType::Mock => ClientType::Mock.as_str(),


### PR DESCRIPTION
Brute force approach for feature gating everything beefy related.

There's likely a better approach, which might involve hiding some types and
functions so that the explore to sp* can be hidden and gated more easily.
