### PR TITLE
Delete all acknowledged packet commitments

### DIFF
--- a/modules/src/core/ics04_channel/context.rs
+++ b/modules/src/core/ics04_channel/context.rs
@@ -170,20 +170,13 @@ pub trait ChannelKeeper {
                 )?;
             }
             PacketResult::Ack(res) => {
-                match res.seq_number {
-                    Some(s) => {
-                        //Ordered Channel
-                        self.store_next_sequence_ack((res.port_id.clone(), res.channel_id), s)?;
-                    }
-                    None => {
-                        //Unordered Channel
-                        self.delete_packet_commitment((
-                            res.port_id.clone(),
-                            res.channel_id,
-                            res.seq,
-                        ))?;
-                    }
+                if let Some(s) = res.seq_number {
+                    //Ordered Channel
+                    self.store_next_sequence_ack((res.port_id.clone(), res.channel_id), s)?;
                 }
+
+                // Delete packet commitment since packet has been aknowledged
+                self.delete_packet_commitment((res.port_id.clone(), res.channel_id, res.seq))?;
             }
             PacketResult::Timeout(res) => {
                 if let Some(c) = res.channel {


### PR DESCRIPTION
Discovered packet commitments for ordered channels were not been deleted after they had been acknowledged.
That would have prevented us from been able to tell the undelivered sequences for ordered channels.