### PR TITLE
Fix timeout processing

### DIFF
--- a/modules/src/core/ics04_channel/error.rs
+++ b/modules/src/core/ics04_channel/error.rs
@@ -72,6 +72,9 @@ define_error! {
         MissingHeight
             | _ | { "invalid proof: missing height" },
 
+        MissingChannelProof
+            | _ | { "invalid proof: missing channel proof" },
+
         MissingNextRecvSeq
             { port_channel_id: (PortId, ChannelId) }
             | e | {
@@ -212,6 +215,16 @@ define_error! {
                     "Receiving chain block height {0} >= packet timeout height {1}",
                     e.chain_height, e.timeout_height)
             },
+        PacketTimeoutNotReached
+            {
+                timeout_height: Height,
+                chain_height: Height,
+                timeout_timestamp: Timestamp,
+                chain_timestamp: Timestamp,
+            }
+            | e | { format_args!(
+                    "Packet timeout not satisified for either packet height or timestamp, Packet timeout height {0}, chain height {1}, Packet timeout timestamp {2},  chain timestamp {3}",
+                     e.timeout_height, e.chain_height, e.timeout_timestamp, e.chain_timestamp) },
 
         PacketTimeoutHeightNotReached
             {

--- a/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -71,7 +71,7 @@ pub(crate) fn process<HostFunctions: HostFunctionsProvider>(
         &channel_end,
         &conn,
         &expected_channel_end,
-        &msg.proofs,
+        &msg.proofs.object_proof(),
     )?;
 
     output.log("success: channel close confirm ");

--- a/modules/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -78,7 +78,7 @@ pub(crate) fn process<HostFunctions: HostFunctionsProvider>(
         &channel_end,
         &conn,
         &expected_channel_end,
-        &msg.proofs,
+        &msg.proofs.object_proof(),
     )?;
 
     output.log("success: channel open ack ");

--- a/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -73,7 +73,7 @@ pub(crate) fn process<HostFunctions: HostFunctionsProvider>(
         &channel_end,
         &conn,
         &expected_channel_end,
-        &msg.proofs,
+        &msg.proofs.object_proof(),
     )
     .map_err(Error::chan_open_confirm_proof_verification)?;
 

--- a/modules/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_try.rs
@@ -97,7 +97,7 @@ pub(crate) fn process<HostFunctions: HostFunctionsProvider>(
         &new_channel_end,
         &conn,
         &expected_channel_end,
-        &msg.proofs,
+        &msg.proofs.object_proof(),
     )?;
 
     output.log("success: channel open try ");

--- a/modules/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -81,7 +81,10 @@ pub fn process<HostFunctions: HostFunctionsProvider>(
         &source_channel_end,
         &connection_end,
         &expected_channel_end,
-        &msg.proofs,
+        msg.proofs
+            .other_proof()
+            .as_ref()
+            .ok_or_else(|| Error::missing_channel_proof())?,
     )?;
 
     let result = if source_channel_end.order_matches(&Order::Ordered) {

--- a/modules/src/core/ics04_channel/handler/verify.rs
+++ b/modules/src/core/ics04_channel/handler/verify.rs
@@ -7,6 +7,7 @@ use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, Sequence};
+use crate::core::ics23_commitment::commitment::CommitmentProofBytes;
 use crate::core::ics26_routing::context::ReaderContext;
 use crate::prelude::*;
 use crate::proofs::Proofs;
@@ -19,7 +20,7 @@ pub fn verify_channel_proofs<HostFunctions: HostFunctionsProvider>(
     channel_end: &ChannelEnd,
     connection_end: &ConnectionEnd,
     expected_chan: &ChannelEnd,
-    proofs: &Proofs,
+    proof: &CommitmentProofBytes,
 ) -> Result<(), Error> {
     // This is the client which will perform proof verification.
     let client_id = connection_end.client_id().clone();
@@ -32,7 +33,7 @@ pub fn verify_channel_proofs<HostFunctions: HostFunctionsProvider>(
     }
 
     let consensus_state = ctx
-        .consensus_state(&client_id, proofs.height())
+        .consensus_state(&client_id, height)
         .map_err(|_| Error::error_invalid_consensus_state())?;
 
     let client_def = AnyClient::<HostFunctions>::from_client_type(client_state.client_type());
@@ -46,7 +47,7 @@ pub fn verify_channel_proofs<HostFunctions: HostFunctionsProvider>(
             &client_state,
             height,
             connection_end.counterparty().prefix(),
-            proofs.object_proof(),
+            &proof,
             consensus_state.root(),
             channel_end.counterparty().port_id(),
             channel_end.counterparty().channel_id().unwrap(),

--- a/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
@@ -64,7 +64,12 @@ impl TryFrom<RawMsgTimeoutOnClose> for MsgTimeoutOnClose {
                 .map_err(Error::invalid_proof)?,
             None,
             None,
-            None,
+            Some(
+                raw_msg
+                    .proof_close
+                    .try_into()
+                    .map_err(Error::invalid_proof)?,
+            ),
             raw_msg
                 .proof_height
                 .ok_or_else(Error::missing_height)?

--- a/modules/src/timestamp.rs
+++ b/modules/src/timestamp.rs
@@ -144,7 +144,7 @@ impl Timestamp {
     pub fn check_expiry(&self, other: &Timestamp) -> Expiry {
         match (self.time, other.time) {
             (Some(time1), Some(time2)) => {
-                if time1 > time2 {
+                if time1 >= time2 {
                     Expiry::Expired
                 } else {
                     Expiry::NotExpired
@@ -271,8 +271,8 @@ mod tests {
         assert!(Timestamp::from_nanoseconds(i64::MAX.try_into().unwrap()).is_ok());
 
         assert_eq!(timestamp1.check_expiry(&timestamp2), Expiry::NotExpired);
-        assert_eq!(timestamp1.check_expiry(&timestamp1), Expiry::NotExpired);
-        assert_eq!(timestamp2.check_expiry(&timestamp2), Expiry::NotExpired);
+        assert_eq!(timestamp1.check_expiry(&timestamp1), Expiry::Expired);
+        assert_eq!(timestamp2.check_expiry(&timestamp2), Expiry::Expired);
         assert_eq!(timestamp2.check_expiry(&timestamp1), Expiry::Expired);
         assert_eq!(
             timestamp1.check_expiry(&nil_timestamp),


### PR DESCRIPTION
Timeout messages should be processed successfully if either the timestamp or timeout height is reached.

Packet timeout calculation should be true at exactly the timeout height and timestamp specified in the packet, not at a block higher or timestamp higher 
Reference https://github.com/cosmos/ibc-go/blob/main/modules/core/04-channel/keeper/timeout.go#L70-L73